### PR TITLE
🔥 Feature: Add docker build options

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+doc/
+Dockerfile*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:24.04
+
+# AstraKernel Dockerfile
+# ======================
+# Run the following to start:
+# $ make docker
+
+# 1. Install dependencies
+RUN apt-get update && apt-get install -y \
+    # Install git for cloning
+    git \
+    # Install bare-metal ARM essentials
+    build-essential gcc-arm-none-eabi binutils-arm-none-eabi \
+    qemu-system-arm \
+    # Clear apt cache
+    && rm -rf /var/lib/apt/lists/*
+
+# 2. Clone the most recent version of the main branch
+WORKDIR /
+RUN git clone --single-branch -b main --depth=1 https://github.com/sandbox-science/AstraKernel.git
+WORKDIR /AstraKernel
+
+# 3. Build/Run via QEMU
+RUN make kernel.bin
+
+CMD ["make", "qemu"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,27 @@
+FROM ubuntu:24.04
+
+# AstraKernel Dockerfile
+# ======================
+# Run the following to start:
+# $ make docker-dev
+
+# 1. Install dependencies
+RUN apt-get update && apt-get install -y \
+    # Install bare-metal ARM essentials
+    build-essential gcc-arm-none-eabi binutils-arm-none-eabi \
+    qemu-system-arm \
+    # Clear apt cache
+    && rm -rf /var/lib/apt/lists/*
+
+# 2. Copy from local FS
+COPY include/ /AstraKernel/include
+COPY kernel/ /AstraKernel/kernel
+COPY user/ /AstraKernel/user
+COPY kernel.ld /AstraKernel
+COPY Makefile /AstraKernel
+WORKDIR /AstraKernel
+
+# 3. Build/Run via QEMU
+RUN make kernel.bin
+
+CMD ["make", "qemu"]

--- a/Makefile
+++ b/Makefile
@@ -53,4 +53,12 @@ qemu:
 	@echo "Press Ctrl-A then X to exit QEMU"
 	@qemu-system-arm -M versatilepb -nographic -kernel $(OUT_DIR)kernel.bin
 
-.PHONY: all clean qemu
+docker:
+	docker build -t "astra-kernel" .
+	docker run -it --rm "astra-kernel"
+
+docker-dev:
+	docker build -f Dockerfile.dev -t "astra-kernel-dev" .
+	docker run -it --rm "astra-kernel-dev"
+
+.PHONY: all clean qemu docker

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Type away, explore, have fun.
 
 ## Building
 
+### Native Build
+
 Make sure you have an ARM cross-compiler installed (e.g., `arm-none-eabi-gcc`) and `qemu-system-arm`.
 
 ```sh
@@ -36,6 +38,21 @@ make
 > 
 > `make` will clean, build, and run the kernel in QEMU. You can also run 
 `make qemu` to run the kernel without cleaning or building it again.
+
+### Docker Build
+
+If you have docker installed, you can also run AstraKernel through a docker container:
+
+```sh
+make docker
+```
+
+> [!IMPORTANT]
+> 
+> `make docker` will pull from the most recent `main` commit from the upstream repository
+> `https://github.com/sanbox-science/AstraKernel.git`.
+> If you wish to use a local copy, you can run `make docker-dev`, which will copy all
+> local build files into the repository.
 
 ## Documentation
 


### PR DESCRIPTION
### Feature Description

This PR adds an option to build `AstraKernel` using Docker. Users can simply run `make docker` to run the latest `main` branch version of docker (or `make docker-dev` to run their checked out local version of AstraKernel for development).

### File Changes

- Add `Dockerfile`, `Dockerfile.dev`, and `.dockerignore` for Docker build support
- Add `docker` and `docker-dev` rules to `Makefile`
- Add docker build instructions to `README.md`

### Feature Example

```console
$ make docker
========================================
  AstraKernel  v0.1.0
  Built May 26 2025 at 06:05:04
========================================

  CPU: ARM926EJ-S @ 200MHz (simulated)
  RAM: 128MB SDRAM at 0x00000000

Welcome to your own little Astra world!
Type away, explore, have fun.

AstraKernel is running...
Press Ctrl-A and then X to exit QEMU.

AstraKernel > 
```