### PR TITLE
🩹 Fix: Update getlines() backspace logic

### DIFF
--- a/user/printf.c
+++ b/user/printf.c
@@ -331,9 +331,9 @@ void getlines(char *restrict buffer, size_t length)
         {
             break;
         }
-        if ((character == '\b' || character == 0x7F) && index > 0) // Check for backspace
+        if (character == '\b' || character == 0x7F) // Check for backspace
         {
-            if (cursor_position > 0)
+            if (cursor_position > 0 && index > 0) // Delete char if present
             {
                 long long initial_pos = cursor_position;
 


### PR DESCRIPTION
### Description

The function `getlines()` improperly handles the backspace character when the buffer is empty (when `index == 0`). This is due to [`user/printf.c:334`](https://github.com/sandbox-science/AstraKernel/blob/0b2ab1948f09a37d40a43565d3d1a8a33863f7cb/user/printf.c#L334):

```c
// Link: https://github.com/sandbox-science/AstraKernel/blob/0b2ab1948f09a37d40a43565d3d1a8a33863f7cb/user/printf.c#L334

        if ((character == '\b' || character == 0x7F) && index > 0) // Check for backspace
            // ...
        }
        else
        {
            putc(character); // Echo the character back

            long long initial_pos = cursor_position;

            for (long long cur = index; cur >= cursor_position; cur--) // Shift characters to the right
            {
                buffer[cur + 1] = buffer[cur];
            }

            buffer[cursor_position] = character; // Store the character in the buffer

            if (index != initial_pos)
            {
                puts(buffer + cursor_position + 1);
                printf("\033[%ldD", index - initial_pos);
            }

            cursor_position++;
            index++;
        }
```

When the buffer is empty (`index = 0`), the backspace logic is skipped and the else block treats the backspace as a regular character.

### Fix

The simple fix is to move the `index > 0` check into the inner if block:

```diff
diff --git a/user/printf.c b/user/printf.c
index d523c6a..44da594 100644
--- a/user/printf.c
+++ b/user/printf.c
@@ -331,9 +331,9 @@ void getlines(char *restrict buffer, size_t length)
         {
             break;
         }
-        if ((character == '\b' || character == 0x7F) && index > 0) // Check for backspace
+        if (character == '\b' || character == 0x7F) // Check for backspace
         {
-            if (cursor_position > 0)
+            if (cursor_position > 0 && index > 0) // Delete char if present
             {
                 long long initial_pos = cursor_position;
```

Fixes: #11 